### PR TITLE
Update CreateOpts struct for PortForwarding Rules

### DIFF
--- a/openstack/networking/v2/extensions/layer3/portforwarding/requests.go
+++ b/openstack/networking/v2/extensions/layer3/portforwarding/requests.go
@@ -64,7 +64,9 @@ type CreateOpts struct {																		// Modified by B.T. Oh
 	PrivateIpAddresss string `json:"vmguestip"`
 	PublicIpId 		  string `json:"entpublicipid"`
 	InternalPort      string `json:"privateport"`
+	InternalEndPort   string `json:"privateendport"`
 	ExternalPort      string `json:"publicport"`
+	ExternalEndPort   string `json:"publicendport"`
 	Protocol          string `json:"protocol"`
 }
 


### PR DESCRIPTION
- Update CreateOpts struct for PortForwarding Rules
  - (KT Cloud D1 Platform) API manual is incorrect.